### PR TITLE
[Fix] Add PHP7 requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
   },
   "keywords": ["cron", "task", "scheduler", "symfony", "bundle"],
   "require": {
+    "php": ">=7",
     "symfony/framework-bundle": "~2.3|~3.0|~4.0",
     "dragonmantank/cron-expression": "^2.0"
   },


### PR DESCRIPTION
Some return type declarations are used in the bundle which are only available in PHP7 and higher.