### PR TITLE
Adding the proper dependencies, as the commands did not know about the container anymore

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -20,9 +20,11 @@
 
     <service id="ts.list_command" class="Rewieer\TaskSchedulerBundle\Command\ListCommand" public="true">
       <tag name="console.command" />
+      <argument type="service" id="ts.scheduler" />
     </service>
     <service id="ts.run_command" class="Rewieer\TaskSchedulerBundle\Command\RunCommand" public="true">
       <tag name="console.command" />
+      <argument type="service" id="ts.scheduler" />
     </service>
   </services>
 </container>


### PR DESCRIPTION
My previous PR added the constructor arguments, but omitted the needed bindings. After upgrading the library in my project, running the commands did not work anymore - this PR fixes this